### PR TITLE
random.rb added

### DIFF
--- a/ruby/random.rb
+++ b/ruby/random.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# 通話に参加するメンバー
+members = %w[A B C D E F].shuffle
+# 最初のグループの人数
+group_size = [2, 3].sample
+
+# 最初のグループメンバー
+p members.slice(0, group_size).sort
+# 残りのグループメンバー
+p members.slice(group_size..-1).sort


### PR DESCRIPTION
## 課題のリンク

[* https://example.com](https://github.com/happiness-chain/practice/blob/main/08_ruby/001_%E3%82%B0%E3%83%AB%E3%83%BC%E3%83%97%E5%88%86%E3%81%91%E5%95%8F%E9%A1%8C.md)

## やったこと
- hc_paracticeリポジトリにrubyディレクトリを作成してrandom.rbファイルで作成する
- mainブランチからgroupブランチを切って、pull requestで提出してください

## 動作確認方法
> ruby random.rbを複数回実行して実行結果すべてをpull requestに記載してください
下記ご参照ください：
![image](https://github.com/sugachan-hc/hc_practice/assets/10960663/3f32d2cc-6b92-4a50-bd1a-185eaa20dc41)

ks@LAPTOP-Q358DMUK-wsl:~/rails/hc_practice/ruby$ ruby random.rb
["B", "F"]
["A", "C", "D", "E"]
ks@LAPTOP-Q358DMUK-wsl:~/rails/hc_practice/ruby$ ruby random.rb
["C", "D"]
["A", "B", "E", "F"]
ks@LAPTOP-Q358DMUK-wsl:~/rails/hc_practice/ruby$ ruby random.rb
["B", "D", "F"]
["A", "C", "E"]
ks@LAPTOP-Q358DMUK-wsl:~/rails/hc_practice/ruby$ ruby random.rb
["A", "D"]
["B", "C", "E", "F"]
ks@LAPTOP-Q358DMUK-wsl:~/rails/hc_practice/ruby$ ruby random.rb
["A", "C", "E"]
["B", "D", "F"]
ks@LAPTOP-Q358DMUK-wsl:~/rails/hc_practice/ruby$ ruby random.rb
["C", "F"]
["A", "B", "D", "E"]
ks@LAPTOP-Q358DMUK-wsl:~/rails/hc_practice/ruby$ ruby random.rb
["A", "B", "C"]
["D", "E", "F"]

## その他
- 前回のHTMLの課題に続いてそのまま操作したところ、現在のPRに前回のHTMLディレクトリ他が残っている状態になっています。課題提出用なので意図通りなのかもしれませんが、成果物としては気持ち悪いように思えました。
意図通りでない場合、不要ファイル・ディレクトリを削除したうえで再提出します。
(次回以降の課題も、今回のように前回の不要なファイル・ディレクトリを含めての提出となるような気がしています。)