### PR TITLE
calendar.rb added.

### DIFF
--- a/ruby/calendar.rb
+++ b/ruby/calendar.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'optparse'
+
+# 年・月の取得
+year = Date.today.year
+month = Date.today.month
+
+# -m オプションの解析
+options = {}
+opt = OptionParser.new
+opt.on('-m month') { |m| options[:month] = m }
+opt.parse!(ARGV)
+
+# オプションなしの場合は当月とする
+target_month = options[:month] || month.to_s
+
+# 不正な月が入力された場合処理を中断
+valid_months = (1..12).to_a.map(&:to_s)
+unless valid_months.include?(target_month)
+  puts "#{target_month} is neither a month number (1..12) nor a name"
+  exit
+end
+
+# 見出し部分
+target_month = target_month.to_i
+week_title = %w[月 火 水 木 金 土 日] # 月曜始まり(仕様)
+puts "      #{target_month}月 #{year}"
+puts week_title.join(' ')
+
+# 指定月の日数
+last_day = Date.new(year, target_month, -1).day
+days = (1..last_day).to_a
+
+# 初日の表示位置から月初の空白日の日数を取得
+wday = Date.new(year, target_month, 1).wday
+first_day_position = wday.zero? ? 6 : wday - 1 # 月曜始まり位置調整
+blank_days = Array.new(first_day_position, ' ')
+
+# 空白日含む日数を格納した配列を7日毎に分割
+output_days = blank_days + days
+weeks = output_days.each_slice(7).to_a
+
+# 各週の要素の桁を揃えて出力
+weeks.each do |week|
+  week.map! do |day|
+    day.to_s.rjust(2, ' ')
+  end
+  puts week.join(' ')
+end
+


### PR DESCRIPTION
## 課題のリンク

[Rubyでカレンダーを作る](https://github.com/happiness-chain/practice/blob/main/08_ruby/002_%E3%82%AB%E3%83%AC%E3%83%B3%E3%83%80%E3%83%BC%E3%82%92%E4%BD%9C%E3%82%8B.md#ruby%E3%81%A7%E3%82%AB%E3%83%AC%E3%83%B3%E3%83%80%E3%83%BC%E3%82%92%E4%BD%9C%E3%82%8B)

## やったこと
- `ruby calendar.rb`で表示されるカレンダーを作成。

## 動作確認方法
`$ ruby calendar.rb` にて実施。
- `-m`オプションで月を指定できる。今年が2023年なら cal -m 10で2023年10月のカレンダーになります。なお、引数を指定しない場合は、今月・今年のカレンダーが表示される。

以下、動作時のスクリーンショットとなります：
- 引数無しパターン、1月-3月
![image](https://github.com/sugachan-hc/hc_practice/assets/10960663/7279d88c-1201-4bb8-ba7f-d413be1e3686)

- 4月-7月
![image](https://github.com/sugachan-hc/hc_practice/assets/10960663/c818af70-c085-48ea-938d-0615459e2dcf)

- 8月-11月
![image](https://github.com/sugachan-hc/hc_practice/assets/10960663/d2241c0e-16fe-4cf2-bac7-2dd785930cd3)

- 12月、引数が不正なパターン( 22月、abc月 )
![image](https://github.com/sugachan-hc/hc_practice/assets/10960663/cfaa504e-94a6-4c98-a1c3-691d02b5d7d1)

## その他
- 「optparseの使い方でブログを書いて提出すること」は別途、提出予定です。